### PR TITLE
Rust Update & Stylo

### DIFF
--- a/org.mozilla.FirefoxNightly/firefox-mozconfig
+++ b/org.mozilla.FirefoxNightly/firefox-mozconfig
@@ -9,3 +9,4 @@ ac_add_options --without-system-icu
 ac_add_options --disable-tests
 ac_add_options --enable-pulseaudio
 ac_add_options --disable-crashreporter
+ac_add_options --enable-stylo=build

--- a/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
+++ b/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
@@ -93,8 +93,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://static.rust-lang.org/dist/rust-1.18.0-x86_64-unknown-linux-gnu.tar.gz",
-                    "sha256": "abdc9f37870c979dd241ba8c7c06d8bb99696292c462ed852c0af7f988bb5887"
+                    "url": "https://static.rust-lang.org/dist/rust-1.19.0-x86_64-unknown-linux-gnu.tar.gz",
+                    "sha256": "30ff67884464d32f6bbbde4387e7557db98868e87fb2afbb77c9b7716e3bff09"
                 },
                 {
                     "type": "script",

--- a/org.mozilla.FirefoxNightlyWayland/firefox-mozconfig
+++ b/org.mozilla.FirefoxNightlyWayland/firefox-mozconfig
@@ -15,4 +15,4 @@ ac_add_options --disable-tests
 ac_add_options --enable-pulseaudio 
 ac_add_options --enable-dbus
 ac_add_options --disable-crashreporter
-ac_add_options --enable-stylo=build
+#ac_add_options --enable-stylo=build

--- a/org.mozilla.FirefoxNightlyWayland/firefox-mozconfig
+++ b/org.mozilla.FirefoxNightlyWayland/firefox-mozconfig
@@ -15,3 +15,4 @@ ac_add_options --disable-tests
 ac_add_options --enable-pulseaudio 
 ac_add_options --enable-dbus
 ac_add_options --disable-crashreporter
+ac_add_options --enable-stylo=build

--- a/org.mozilla.FirefoxNightlyWayland/org.mozilla.FirefoxNightlyWayland.json
+++ b/org.mozilla.FirefoxNightlyWayland/org.mozilla.FirefoxNightlyWayland.json
@@ -94,8 +94,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://static.rust-lang.org/dist/rust-1.18.0-x86_64-unknown-linux-gnu.tar.gz",
-                    "sha256": "abdc9f37870c979dd241ba8c7c06d8bb99696292c462ed852c0af7f988bb5887"
+                    "url": "https://static.rust-lang.org/dist/rust-1.19.0-x86_64-unknown-linux-gnu.tar.gz",
+                    "sha256": "30ff67884464d32f6bbbde4387e7557db98868e87fb2afbb77c9b7716e3bff09"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
Stylo is still disabled by default, so this change will affect only users who opt-in to this feature.

FirefoxNightly built fine, Wayland is still building.