### PR TITLE
Upstream binary update 55

### DIFF
--- a/org.mozilla.FirefoxUpstreamBinary/org.mozilla.FirefoxUpstreamBinary.json
+++ b/org.mozilla.FirefoxUpstreamBinary/org.mozilla.FirefoxUpstreamBinary.json
@@ -40,8 +40,8 @@
           "sources": [
               {
                   "type": "archive",
-                  "url": "https://archive.mozilla.org/pub/firefox/releases/52.0.1/linux-x86_64/en-US/firefox-52.0.1.tar.bz2",
-                  "sha256": "086aba1a19a395d189d04ea951e7555e44c06ccf9a5fd77ce005108559808dcc",
+                  "url": "https://archive.mozilla.org/pub/firefox/releases/55.0/linux-x86_64/en-US/firefox-55.0.tar.bz2",
+                  "sha256": "be8c22ac815af71eebbce83e2a646a10d9d875b4a470a7b251efe94ddb7045df",
                   "dest": "firefox"
               },
               {

--- a/org.mozilla.FirefoxUpstreamBinary/org.mozilla.FirefoxUpstreamBinary.json
+++ b/org.mozilla.FirefoxUpstreamBinary/org.mozilla.FirefoxUpstreamBinary.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.mozilla.FirefoxUpstreamBinary",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.22",
+    "runtime-version": "3.24",
     "sdk": "org.gnome.Sdk",
     "command": "firefox",
     /*"tags": [""],*/


### PR DESCRIPTION
Updated upstream binary Flatpak to use the same sandbox arguments as Nightly, use the latest GNOME SDK, and upgraded from Firefox 52.0.1 to 55.0.