### PR TITLE
Upgraded to Rust 1.19

### DIFF
--- a/org.mozilla.FirefoxDevEdition/org.mozilla.FirefoxDevEdition.json
+++ b/org.mozilla.FirefoxDevEdition/org.mozilla.FirefoxDevEdition.json
@@ -89,8 +89,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://static.rust-lang.org/dist/rust-1.16.0-x86_64-unknown-linux-gnu.tar.gz",
-                    "sha256": "48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd"
+                    "url": "https://static.rust-lang.org/dist/rust-1.19.0-x86_64-unknown-linux-gnu.tar.gz",
+                    "sha256": "30ff67884464d32f6bbbde4387e7557db98868e87fb2afbb77c9b7716e3bff09"
                 },
                 {
                     "type": "script",

--- a/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
+++ b/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
@@ -93,8 +93,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://static.rust-lang.org/dist/rust-1.18.0-x86_64-unknown-linux-gnu.tar.gz",
-                    "sha256": "abdc9f37870c979dd241ba8c7c06d8bb99696292c462ed852c0af7f988bb5887"
+                    "url": "https://static.rust-lang.org/dist/rust-1.19.0-x86_64-unknown-linux-gnu.tar.gz",
+                    "sha256": "30ff67884464d32f6bbbde4387e7557db98868e87fb2afbb77c9b7716e3bff09"
                 },
                 {
                     "type": "script",

--- a/org.mozilla.FirefoxNightlyWayland/org.mozilla.FirefoxNightlyWayland.json
+++ b/org.mozilla.FirefoxNightlyWayland/org.mozilla.FirefoxNightlyWayland.json
@@ -94,8 +94,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://static.rust-lang.org/dist/rust-1.18.0-x86_64-unknown-linux-gnu.tar.gz",
-                    "sha256": "abdc9f37870c979dd241ba8c7c06d8bb99696292c462ed852c0af7f988bb5887"
+                    "url": "https://static.rust-lang.org/dist/rust-1.19.0-x86_64-unknown-linux-gnu.tar.gz",
+                    "sha256": "30ff67884464d32f6bbbde4387e7557db98868e87fb2afbb77c9b7716e3bff09"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
Updated all nightly Flatpaks to use Rust 1.19.0, thus allowing for Stylo to be built (as well as future Rust components).