### PR TITLE
Added functionality to build upstream Nightly as a Flatpak

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,21 @@ else
   APP_NAME=$1
 fi
 
+# Prepare Nightly Upstream (with correct URL & checksum)
+if [[ $APP_NAME == 'org.mozilla.FirefoxNightlyUpstreamBinary' ]]
+then
+  # Not sure how to automate the version string yet
+  # (needs changing every 6 weeks or so)
+  VERSION=57.0
+
+  FILE=${APP_NAME}/${APP_NAME}.json
+  URL=https://download-installer.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-central/firefox-${VERSION}a1.en-US.linux-x86_64.checksums
+  TARBALL=https://download-installer.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-central/firefox-${VERSION}a1.en-US.linux-x86_64.tar.bz2
+  CHECKSUM=$(curl ${URL} | grep sha256 | grep bz2$ | cut -f1 -d' ')
+
+  sed -i "s|url\".*|url\"\: \"$TARBALL\"\,|" "$FILE"
+  sed -i "s|sha256\".*|sha256\"\: \"$CHECKSUM\"\,|" "$FILE"
+fi
 
 # Build repo
 flatpak-builder $GPG_SETTINGS --verbose --force-clean --ccache --require-changes --repo=repo --subject="Build of $APP_NAME" app $APP_NAME/$APP_NAME.json
@@ -21,3 +36,9 @@ flatpak build-update-repo $GPG_SETTINGS --prune --prune-depth=2 repo
 
 # Build .flatpak file
 flatpak build-bundle $GPG_BUNDLE_SETTINGS repo $APP_NAME.flatpak $APP_NAME
+
+# Clean up Nightly Upstream (if applicable)
+if [[ $APP_NAME == 'org.mozilla.FirefoxNightlyUpstreamBinary' ]]
+then
+  git checkout HEAD "$FILE"
+fi

--- a/org.mozilla.FirefoxNightlyUpstreamBinary/org.mozilla.Firefox.appdata.xml
+++ b/org.mozilla.FirefoxNightlyUpstreamBinary/org.mozilla.Firefox.appdata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2016 Jiri Eischmann <eischmann@redhat.com> -->
+<application>
+  <id type="desktop">org.mozilla.FirefoxNightlyUpstreamBinary.desktop</id>
+  <name>Firefox Nightly</name>
+  <summary>Firefox Nightly Web Browser</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MPL-2.0</project_license>
+  <description>
+    <p>
+      Bringing together all kinds of awesomeness to make browsing better for you. Get to your favorite sites quickly – even if you don’t remember the URLs. Type your term into the location bar (aka the Awesome Bar) and the autocomplete function will include possible matches from your browsing history, bookmarked sites and open tabs.
+    </p>
+    <p>
+      Firefox Nightly brings latest Mozilla code to your computer.
+    </p>
+    <!-- FIXME: Needs more paragraphs -->
+  </description>
+  <keywords>
+    <keyword>mozilla</keyword>
+    <keyword>internet</keyword>
+    <keyword>web</keyword>
+  </keywords>
+  <url type="homepage">https://www.mozilla.org/firefox/channel/desktop/#nightly</url>
+  <screenshots>
+    <screenshot type="default">https://dl.dropboxusercontent.com/u/1309518/firefox-de.png</screenshot>
+    <screenshot>https://dl.dropboxusercontent.com/u/1309518/firefox-de2.png</screenshot>
+    <screenshot>https://dl.dropboxusercontent.com/u/1309518/firefox-de3.png</screenshot>
+  </screenshots>
+  <!-- FIXME: change this to an upstream email address for spec updates
+  <updatecontact>someone_who_cares@upstream_project.org</updatecontact>
+   -->
+</application>

--- a/org.mozilla.FirefoxNightlyUpstreamBinary/org.mozilla.Firefox.desktop
+++ b/org.mozilla.FirefoxNightlyUpstreamBinary/org.mozilla.Firefox.desktop
@@ -1,0 +1,62 @@
+[Desktop Entry]
+Version=1.0
+Name=Firefox
+GenericName=Web Browser
+GenericName[ca]=Navegador web
+GenericName[cs]=Webový prohlížeč
+GenericName[es]=Navegador web
+GenericName[fa]=مرورگر اینترنتی
+GenericName[fi]=WWW-selain
+GenericName[fr]=Navigateur Web
+GenericName[hu]=Webböngésző
+GenericName[it]=Browser Web
+GenericName[ja]=ウェブ・ブラウザ
+GenericName[ko]=웹 브라우저
+GenericName[nb]=Nettleser
+GenericName[nl]=Webbrowser
+GenericName[nn]=Nettlesar
+GenericName[no]=Nettleser
+GenericName[pl]=Przeglądarka WWW
+GenericName[pt]=Navegador Web
+GenericName[pt_BR]=Navegador Web
+GenericName[sk]=Internetový prehliadač
+GenericName[sv]=Webbläsare
+Comment=Browse the Web
+Comment[ca]=Navegueu per el web
+Comment[cs]=Prohlížení stránek World Wide Webu
+Comment[de]=Im Internet surfen
+Comment[es]=Navegue por la web
+Comment[fa]=صفحات شبکه جهانی اینترنت را مرور نمایید
+Comment[fi]=Selaa Internetin WWW-sivuja
+Comment[fr]=Navigue sur Internet
+Comment[hu]=A világháló böngészése
+Comment[it]=Esplora il web
+Comment[ja]=ウェブを閲覧します
+Comment[ko]=웹을 돌아 다닙니다
+Comment[nb]=Surf på nettet
+Comment[nl]=Verken het internet
+Comment[nn]=Surf på nettet
+Comment[no]=Surf på nettet
+Comment[pl]=Przeglądanie stron WWW
+Comment[pt]=Navegue na Internet
+Comment[pt_BR]=Navegue na Internet
+Comment[sk]=Prehliadanie internetu
+Comment[sv]=Surfa på webben
+Exec=firefox %u
+Icon=org.mozilla.Firefox
+Terminal=false
+Type=Application
+MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
+StartupNotify=true
+Categories=Network;WebBrowser;
+Keywords=web;browser;internet;
+Actions=new-window;new-private-window;
+
+[Desktop Action new-window]
+Name=Open a New Window
+Exec=firefox %u
+
+[Desktop Action new-private-window]
+Name=Open a New Private Window
+Exec=firefox --private-window %u
+

--- a/org.mozilla.FirefoxNightlyUpstreamBinary/org.mozilla.FirefoxNightlyUpstreamBinary.json
+++ b/org.mozilla.FirefoxNightlyUpstreamBinary/org.mozilla.FirefoxNightlyUpstreamBinary.json
@@ -1,0 +1,87 @@
+{
+    "app-id": "org.mozilla.FirefoxNightlyUpstreamBinary",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.24",
+    "sdk": "org.gnome.Sdk",
+    "command": "firefox",
+    /*"tags": [""],*/
+    "desktop-file-name-suffix": " Nightly Upstream Binary",
+    "rename-desktop-file": "org.mozilla.Firefox.desktop",
+    "rename-appdata-file" : "org.mozilla.Firefox.appdata.xml",
+    "rename-icon" : "org.mozilla.Firefox",
+    "finish-args": [
+        /* X11 + XShm access */
+        "--share=ipc", "--socket=x11",
+        /* We don't want full fs access so we can read the files */
+        /*"--filesystem=home:rw",*/
+        /* Needs to talk to the network: */
+        "--share=network",
+        /* Enable playing sound thru pulseaudio */
+        "--socket=pulseaudio",
+        /* Keep user profile after application exit */
+        "--persist=.mozilla/",
+        /* Allow access to Download folder */
+        "--filesystem=xdg-download:rw"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": ["/include", "/lib/pkgconfig",
+                "/share/pkgconfig", "/share/aclocal",
+                "/man", "/share/man", "/share/gtk-doc",
+                "*.la", "*.a"],
+    "modules": [
+      {
+          "name": "firefox",
+          "no-autogen": true,
+          "make-install-args": ["prefix=/app"],
+          "sources": [
+              {
+                  "type": "archive",
+                  "url": "https://download-installer.cdn.mozilla.net/pub/firefox/nightly/latest-mozilla-central/firefox-57.0a1.en-US.linux-x86_64.tar.bz2",
+                  "sha256": "a277cca897a4f51f487f474af7913850cb17d04de7b9f9911012649908081c87",
+                  "dest": "firefox"
+              },
+              {
+                  /* Used for putting upstream build into the right location */
+                  "type": "script",
+                  "commands": ["all:",
+                               "	echo 'Nothing to do'",
+                               "install:",
+                               "	mkdir -p /app/lib/firefox",
+                               "	cp -r firefox $(prefix)/lib",
+                               "	mkdir -p $(prefix)/bin",
+                               "	cp -p firefox.sh $(prefix)/bin/firefox",
+                               "	chmod +x $(prefix)/bin/firefox",
+                               "	mkdir -p $(prefix)/share/appdata",
+                               "	cp -p org.mozilla.Firefox.appdata.xml $(prefix)/share/appdata",
+                               "	desktop-file-install --dir $(prefix)/share/applications org.mozilla.Firefox.desktop",
+                               "	mkdir -p $(prefix)/share/icons/hicolor/128x128/apps/ $(prefix)/share/appdata",
+                               "	cp -p firefox/browser/icons/mozicon128.png $(prefix)/share/icons/hicolor/128x128/apps/org.mozilla.Firefox.png"
+                              ],
+                  "dest-filename": "Makefile"
+              },
+              {
+                  /* Execution script to start Firefox */
+                  "type": "script",
+                  "commands": ["/app/lib/firefox/run-mozilla.sh /app/lib/firefox/firefox $*"],
+                  "dest-filename": "firefox.sh"
+              },
+              {
+                  "type": "file",
+                  "path": "org.mozilla.Firefox.appdata.xml",
+                  "dest": ""
+              },
+              {
+                  "type": "file",
+                  "path": "org.mozilla.Firefox.desktop",
+                  "dest": ""
+              }
+          ]
+      }
+    ]
+}


### PR DESCRIPTION
Based on the Firefox upstream release Flatpak with some tweaks, here's functionality to build Nightly as a Flatpak. It figures out the URL and checksum based on the release version (which currently needs to be bumped every 6 weeks or so).