### PR TITLE
Add support for Flatpak themes

### DIFF
--- a/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
+++ b/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
@@ -27,7 +27,10 @@
         /* Allow access to Download folder */
         "--filesystem=xdg-download:rw",
         /* Enable access to dri */
-        "--device=dri"
+        "--device=dri",
+        /* Enable themes support */
+        "--filesystem=~/.config/dconf:ro",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "build-options" : {
         "cflags": "-O2 -g",


### PR DESCRIPTION
Flatpak supports now [GTK Desktop themes](https://tingping.github.io/2017/05/11/flatpak-theming.html), you can look into this issue https://github.com/flatpak/flatpak/issues/114.

By adding the following 2 options to the `finish-args` list, you gain this feature:
```json
[
    "--filesystem=~/.config/dconf:ro",
    "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
]
```

These lines mount `~/.conf/dconf` in readonly mode to the flatpak, so `gsettings` (or whatever tool queries desktop settings) can read the proper theme name from the host configuration, and then can find it in `/usr/share/runtime/share/themes/` as a theme extension if it's installed, or fallback to the default theme of this runtime.

Here's a screenshot from Firefox with [Adpata theme](https://github.com/flathub/org.gtk.Gtk3theme.Adapta):

![screenshot from 2018-02-03 20-22-22](https://user-images.githubusercontent.com/928614/35770225-f6e9eeaa-091f-11e8-8ff3-4b45be87754e.png)
