### PR TITLE
org.mozilla.FirefoxNightly.json: --persist dir can't end with /

### DIFF
--- a/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
+++ b/org.mozilla.FirefoxNightly/org.mozilla.FirefoxNightly.json
@@ -23,7 +23,7 @@
         /* Enable playing sound thru pulseaudio */
         "--socket=pulseaudio",
         /* Keep user profile after application exit */
-        "--persist=.mozilla/",
+        "--persist=.mozilla",
         /* Allow access to Download folder */
         "--filesystem=xdg-download:rw",
         /* Enable access to dri */


### PR DESCRIPTION
In flatpak 0.11 and above if a directory marked as --persist ends with / it
will behave like rsync, i.e, the named directory will be created and under
it we will have the persisted dir, in this case we will have
.mozilla/.mozilla/ . And firefox won't load previously created profile.

Signed-off-by: Bruno Ribas <brunoribas@gmail.com>