### PR TITLE
Remove file access to home dir

### DIFF
--- a/org.mozilla.FirefoxDevEdition/org.mozilla.FirefoxDevEdition.json
+++ b/org.mozilla.FirefoxDevEdition/org.mozilla.FirefoxDevEdition.json
@@ -17,8 +17,6 @@
         "--share=ipc", "--socket=x11",
         /* Wayland access */
         "--socket=wayland",
-        /* We want full fs access so we can read the files */
-        "--filesystem=home:rw",
         /* Needs to talk to the network: */
         "--share=network",
         /* Use dark decorations for window */


### PR DESCRIPTION
Firefox 62 is stable since a long time, so dev edition does ship with portals since a long time.

So as in Nightly (see https://github.com/xhorak/firefox-devedition-flatpak/issues/101) we can likely remove the home dir permission to strengthen the security.