### PR TITLE
[FirefoxUpstreamBinary] Switch to Freedesktop-19.08

### DIFF
--- a/org.mozilla.FirefoxUpstreamBinary/org.mozilla.FirefoxUpstreamBinary.json.template
+++ b/org.mozilla.FirefoxUpstreamBinary/org.mozilla.FirefoxUpstreamBinary.json.template
@@ -1,8 +1,8 @@
 {
     "app-id": "org.mozilla.FirefoxUpstreamBinary",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
-    "sdk": "org.gnome.Sdk",
+    "runtime":"org.freedesktop.Platform",
+    "runtime-version":"19.08",
+    "sdk":"org.freedesktop.Sdk",
     "command": "firefox",
     /*"tags": [""],*/
     "desktop-file-name-suffix": " Upstream Binary",
@@ -29,6 +29,15 @@
         "--socket=session-bus"
     ],
     "modules": [
+      {
+         "name":"dbus-glib",
+         "sources":[
+            {
+               "type":"git",
+               "url":"https://github.com/freedesktop/dbus-glib.git"
+            }
+         ]
+      },
       {
           "name": "firefox",
           "no-autogen": true,


### PR DESCRIPTION
I was also hit by the segfault bug, so I tried to package upstream firefox to flatpak, as flatpak is the only viable option for me  on clear-linux to get a featureful ffmpeg. A bare version worked fine. Then I discovered, that you also have this covered in this repository, but with an outdated runtime. Thus, I combined what I had with what you have to build this PR. Hope you find it useful :)

The build works fine for me. It would seem `dbus-glib`is the only thing which is missing from `freedesktop-19.08.`

Tested with:

``sh
./build_flatpak_from_url http://archive.mozilla.org/pub/firefox/candidates/70.0.1-candidates/build1/linux-x86_64/en-US/firefox-70.0.1.tar.bz2
``