### PR TITLE
Add ProfileManager to the right click menu.

### DIFF
--- a/org.mozilla.FirefoxDevEdition/org.mozilla.Firefox.desktop
+++ b/org.mozilla.FirefoxDevEdition/org.mozilla.Firefox.desktop
@@ -50,7 +50,7 @@ MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xm
 StartupNotify=true
 Categories=Network;WebBrowser;
 Keywords=web;browser;internet;
-Actions=new-window;new-private-window;
+Actions=new-window;new-private-window;profilemanager;
 
 [Desktop Action new-window]
 Name=Open a New Window
@@ -59,4 +59,8 @@ Exec=firefox %u
 [Desktop Action new-private-window]
 Name=Open a New Private Window
 Exec=firefox --private-window %u
+
+[Desktop Action profilemanager]
+Name=Open the Profile Manager
+Exec=firefox --ProfileManager %u
 

--- a/org.mozilla.FirefoxNightly/org.mozilla.Firefox.desktop
+++ b/org.mozilla.FirefoxNightly/org.mozilla.Firefox.desktop
@@ -50,7 +50,7 @@ MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xm
 StartupNotify=true
 Categories=Network;WebBrowser;
 Keywords=web;browser;internet;
-Actions=new-window;new-private-window;
+Actions=new-window;new-private-window;profilemanager;
 
 [Desktop Action new-window]
 Name=Open a New Window
@@ -59,4 +59,8 @@ Exec=firefox %u
 [Desktop Action new-private-window]
 Name=Open a New Private Window
 Exec=firefox --private-window %u
+
+[Desktop Action profilemanager]
+Name=Open the Profile Manager
+Exec=firefox --ProfileManager %u
 

--- a/org.mozilla.FirefoxUpstreamBinary/org.mozilla.Firefox.desktop
+++ b/org.mozilla.FirefoxUpstreamBinary/org.mozilla.Firefox.desktop
@@ -50,7 +50,7 @@ MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xm
 StartupNotify=true
 Categories=Network;WebBrowser;
 Keywords=web;browser;internet;
-Actions=new-window;new-private-window;
+Actions=new-window;new-private-window;profilemanager;
 
 [Desktop Action new-window]
 Name=Open a New Window
@@ -59,4 +59,8 @@ Exec=firefox %u
 [Desktop Action new-private-window]
 Name=Open a New Private Window
 Exec=firefox --private-window %u
+
+[Desktop Action profilemanager]
+Name=Open the Profile Manager
+Exec=firefox --ProfileManager %u
 


### PR DESCRIPTION
Continuum of #146 
Closes #144

When building:
```
jc@Ubuntu-1910-eoan-64-minimal:~/firefox-devedition-flatpak$ ./build.sh org.mozilla.FirefoxDevEdition/
    Updating crates.io index
     Ignored package `cargo-vendor v0.1.23` is already installed, use --force to override
   Vendoring ansi_term v0.11.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/ansi_term-0.11.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/ansi_term
   Vendoring atty v0.2.14 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/atty-0.2.14) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/atty
   Vendoring bitflags v1.2.1 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/bitflags-1.2.1) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/bitflags
   Vendoring cbindgen v0.13.2 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/cbindgen-0.13.2) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/cbindgen
   Vendoring cfg-if v0.1.10 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/cfg-if-0.1.10) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/cfg-if
   Vendoring clap v2.33.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/clap
   Vendoring getrandom v0.1.14 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.1.14) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/getrandom
   Vendoring hermit-abi v0.1.11 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/hermit-abi-0.1.11) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/hermit-abi
   Vendoring itoa v0.4.5 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/itoa-0.4.5) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/itoa
   Vendoring libc v0.2.69 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.69) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/libc
   Vendoring log v0.4.8 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.8) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/log
   Vendoring ppv-lite86 v0.2.6 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/ppv-lite86-0.2.6) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/ppv-lite86
   Vendoring proc-macro2 v1.0.10 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.10) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/proc-macro2
   Vendoring quote v1.0.3 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/quote-1.0.3) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/quote
   Vendoring rand v0.7.3 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.7.3) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/rand
   Vendoring rand_chacha v0.2.2 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_chacha-0.2.2) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/rand_chacha
   Vendoring rand_core v0.5.1 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_core-0.5.1) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/rand_core
   Vendoring rand_hc v0.2.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_hc-0.2.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/rand_hc
   Vendoring redox_syscall v0.1.56 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.1.56) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/redox_syscall
   Vendoring remove_dir_all v0.5.2 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/remove_dir_all-0.5.2) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/remove_dir_all
   Vendoring ryu v1.0.3 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.3) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/ryu
   Vendoring serde v1.0.106 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.106) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/serde
   Vendoring serde_derive v1.0.106 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_derive-1.0.106) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/serde_derive
   Vendoring serde_json v1.0.51 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.51) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/serde_json
   Vendoring strsim v0.8.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/strsim-0.8.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/strsim
   Vendoring syn v1.0.17 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/syn-1.0.17) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/syn
   Vendoring tempfile v3.1.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/tempfile-3.1.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/tempfile
   Vendoring textwrap v0.11.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/textwrap-0.11.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/textwrap
   Vendoring toml v0.5.6 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/toml-0.5.6) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/toml
   Vendoring unicode-width v0.1.7 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/unicode-width-0.1.7) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/unicode-width
   Vendoring unicode-xid v0.2.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/unicode-xid
   Vendoring vec_map v0.8.1 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/vec_map-0.8.1) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/vec_map
   Vendoring wasi v0.9.0+wasi-snapshot-preview1 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/wasi-0.9.0+wasi-snapshot-preview1) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/wasi
   Vendoring winapi v0.3.8 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.8) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/winapi
   Vendoring winapi-i686-pc-windows-gnu v0.4.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/winapi-i686-pc-windows-gnu
   Vendoring winapi-x86_64-pc-windows-gnu v0.4.0 (/home/jc/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0) to /home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/vendor/winapi-x86_64-pc-windows-gnu
To use vendored sources, add this to your .cargo/config for this project:

[source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
Sources prepared
/home/jc/firefox-devedition-flatpak
FB: Running: git config --get user.email
FB: Running: git config --get user.name
Can't load 'org.mozilla.FirefoxDevEdition//org.mozilla.FirefoxDevEdition/.json': Failed to open file “/home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/org.mozilla.FirefoxDevEdition/.json”: No such file or directory
```
It needs a json file, what does not exist in `/home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition` nor `/home/jc/firefox-devedition-flatpak/org.mozilla.FirefoxDevEdition/org.mozilla.FirefoxDevEdition`.  
@erAck What can I do to acquire the `.json`?